### PR TITLE
Update obsolete MATLAB functions

### DIFF
--- a/gui/get_pathloc.m
+++ b/gui/get_pathloc.m
@@ -7,7 +7,7 @@ function pathloc = get_pathloc(loc)
 % loc is the location given
 % pathloc is the resulting location (in quotes if a path)
 
-if isempty(findstr(loc,'/')) && isempty(findstr(loc,'\')) && isempty(findstr(loc,'.'))
+if ~contains(loc,'/') && ~contains(loc,'\') && ~contains(loc,'.')
     pathloc = loc;
 else
     pathloc = strcat('''',loc,'''');

--- a/gui/gui_analyze_data.m
+++ b/gui/gui_analyze_data.m
@@ -129,7 +129,7 @@ set(handles.data,'String',contents{get(hObject,'Value')});
 
 % load data
 loc = get(handles.data,'String');
-if isempty(findstr(loc,'/')) && isempty(findstr(loc,'\'))...
+if ~contains(loc,'/') && ~contains(loc,'\')...
         && evalin('base',strcat('exist(''',loc,''',''var'')'))
     handles.datavar = evalin('base',loc);
 elseif exist(loc) == 2
@@ -168,7 +168,7 @@ function data_Callback(hObject, eventdata, handles)
 
 % load data
 loc = get(handles.data,'String');
-if isempty(findstr(loc,'/')) && isempty(findstr(loc,'\'))...
+if ~contains(loc,'/') && ~contains(loc,'\')...
         && evalin('base',strcat('exist(''',loc,''',''var'')'))
     handles.datavar = evalin('base',loc);
 elseif exist(loc) == 2
@@ -291,7 +291,7 @@ set(handles.data,'String',[pn fn]);
 
 % load data
 loc = get(handles.data,'String');
-if isempty(findstr(loc,'/')) && isempty(findstr(loc,'\'))...
+if ~contains(loc,'/') && ~contains(loc,'\')...
         && evalin('base',strcat('exist(''',loc,''',''var'')'))
     handles.datavar = evalin('base',loc);
 elseif exist(loc) == 2
@@ -572,9 +572,9 @@ function tolerance_amplitude_text_Callback(hObject, eventdata, handles)
 
 % Hints: get(hObject,'String') returns contents of tolerance_amplitude_text as text
 %        str2double(get(hObject,'String')) returns contents of tolerance_amplitude_text as a double
-set(handles.tolerance_amplitude,'Value',0.01*str2num(get(hObject,'String')));
+set(handles.tolerance_amplitude,'Value',0.01*str2double(get(hObject,'String')));
 if ~isempty(get(handles.wavelength,'String'))
-    handles.tolampwv(get(handles.wavelength,'Value')) = 0.01*str2num(get(hObject,'String'));
+    handles.tolampwv(get(handles.wavelength,'Value')) = 0.01*str2double(get(hObject,'String'));
 end
 
 handles = display_plots(handles);
@@ -603,9 +603,9 @@ function tolerance_phase_text_Callback(hObject, eventdata, handles)
 
 % Hints: get(hObject,'String') returns contents of tolerance_phase_text as text
 %        str2double(get(hObject,'String')) returns contents of tolerance_phase_text as a double
-set(handles.tolerance_phase,'Value',0.01*str2num(get(hObject,'String')));
+set(handles.tolerance_phase,'Value',0.01*str2double(get(hObject,'String')));
 if ~isempty(get(handles.wavelength,'String'))
-    handles.tolphwv(get(handles.wavelength,'Value')) = 0.01*str2num(get(hObject,'String'));
+    handles.tolphwv(get(handles.wavelength,'Value')) = 0.01*str2double(get(hObject,'String'));
 end
 
 handles = display_plots(handles);
@@ -639,7 +639,7 @@ set(handles.mesh,'String',contents{get(hObject,'Value')});
 
 % load the mesh
 loc = get(handles.mesh,'String');
-if isempty(findstr(loc,'/')) && isempty(findstr(loc,'\'))...
+if ~contains(loc,'/') && ~contains(loc,'\')...
         && evalin('base',strcat('exist(''',loc,''',''var'')'))
     handles.meshvar = evalin('base',loc);
 elseif exist([loc '.node']) == 2
@@ -719,7 +719,7 @@ function mesh_Callback(hObject, eventdata, handles)
 
 % load the mesh
 loc = get(handles.mesh,'String');
-if isempty(findstr(loc,'/')) && isempty(findstr(loc,'\'))...
+if ~contains(loc,'/') && ~contains(loc,'\')...
         && evalin('base',strcat('exist(''',loc,''',''var'')'))
     handles.meshvar = evalin('base',loc);
 elseif exist([loc '.node']) == 2
@@ -801,7 +801,7 @@ set(handles.mesh,'String',temp(1:end-5));
 
 % load the mesh
 loc = get(handles.mesh,'String');
-if isempty(findstr(loc,'/')) && isempty(findstr(loc,'\'))...
+if ~contains(loc,'/') && ~contains(loc,'\')...
         && evalin('base',strcat('exist(''',loc,''',''var'')'))
     handles.meshvar = evalin('base',loc);
 elseif exist([loc '.node']) == 2
@@ -940,9 +940,9 @@ function lower_text_Callback(hObject, eventdata, handles)
 
 % Hints: get(hObject,'String') returns contents of lower_text as text
 %        str2double(get(hObject,'String')) returns contents of lower_text as a double
-set(handles.lower,'Value',str2num(get(hObject,'String')));
+set(handles.lower,'Value',str2double(get(hObject,'String')));
 if ~isempty(get(handles.wavelength,'String'))
-    handles.lowerwv(get(handles.wavelength,'Value')) = str2num(get(hObject,'String'));
+    handles.lowerwv(get(handles.wavelength,'Value')) = str2double(get(hObject,'String'));
 end
 
 handles = display_plots(handles);
@@ -1001,9 +1001,9 @@ function upper_text_Callback(hObject, eventdata, handles)
 
 % Hints: get(hObject,'String') returns contents of upper_text as text
 %        str2double(get(hObject,'String')) returns contents of upper_text as a double
-set(handles.upper,'Value',str2num(get(hObject,'String')));
+set(handles.upper,'Value',str2double(get(hObject,'String')));
 if ~isempty(get(handles.wavelength,'String'))
-    handles.upperwv(get(handles.wavelength,'Value')) = str2num(get(hObject,'String'));
+    handles.upperwv(get(handles.wavelength,'Value')) = str2double(get(hObject,'String'));
 end
 
 handles = display_plots(handles);

--- a/gui/gui_create_mesh.m
+++ b/gui/gui_create_mesh.m
@@ -176,7 +176,7 @@ shape = shapeobj{get(handles.shape,'Value')};
 
    
 if strcmp(shape,'Circle') && ~isempty(get(handles.radius,'String'))
-    smallest = str2num(get(handles.radius,'String'));
+    smallest = str2double(get(handles.radius,'String'));
     if isempty(get(handles.distance,'String'))
         set(handles.distance,'String',num2str(smallest*0.025));
     end
@@ -184,8 +184,8 @@ end
 
 if strcmp(shape,'Rectangle') && ~isempty(get(handles.width,'String')) ...
         && ~isempty(get(handles.height,'String'))
-    smallest = min([str2num(get(handles.width,'String')), ...
-                    str2num(get(handles.height,'String'))]);
+    smallest = min([str2double(get(handles.width,'String')), ...
+                    str2double(get(handles.height,'String'))]);
     if isempty(get(handles.distance,'String'))
         set(handles.distance,'String',num2str(smallest*0.025));
     end
@@ -193,8 +193,8 @@ end
 
 if strcmp(shape,'Cylinder') && ~isempty(get(handles.radius,'String')) ...
         && ~isempty(get(handles.height,'String'))
-    smallest = min([str2num(get(handles.radius,'String')), ...
-                    str2num(get(handles.height,'String'))]);
+    smallest = min([str2double(get(handles.radius,'String')), ...
+                    str2double(get(handles.height,'String'))]);
     if isempty(get(handles.distance,'String'))
         set(handles.distance,'String',num2str(smallest*0.035));
     end
@@ -203,9 +203,9 @@ end
 if strcmp(shape,'Slab') && ~isempty(get(handles.width,'String')) ...
         && ~isempty(get(handles.height,'String')) ...
         && ~isempty(get(handles.depth,'String'))
-    smallest = min([str2num(get(handles.width,'String')), ...
-                    str2num(get(handles.height,'String')), ...
-                    str2num(get(handles.depth,'String'))]);
+    smallest = min([str2double(get(handles.width,'String')), ...
+                    str2double(get(handles.height,'String')), ...
+                    str2double(get(handles.depth,'String'))]);
     if isempty(get(handles.distance,'String'))
         set(handles.distance,'String',num2str(smallest*0.035));
     end

--- a/gui/gui_forward_solver.m
+++ b/gui/gui_forward_solver.m
@@ -418,8 +418,8 @@ if get(handles.view_solution,'Value')
             evalin('base',content{end});
         end
     end
-    src1 = str2num(get(handles.source1,'String'));
-    src2 = str2num(get(handles.source2,'String'));
+    src1 = str2double(get(handles.source1,'String'));
+    src2 = str2double(get(handles.source2,'String'));
     for i=src1:1:src2
         content{end+1} = strcat('plotimage(mesh',...
             ',log(',varname,'.phi(:,',num2str(i),'))); pause(0.2);');

--- a/gui/gui_place_sources_detectors.m
+++ b/gui/gui_place_sources_detectors.m
@@ -504,7 +504,7 @@ if get(handles.row_type,'Value')==1
     sources = get(handles.sources,'String');
     data1 = textscan(p1,'%.54f');
     data2 = textscan(p2,'%.54f');
-    numpoints = str2num(get(handles.row_number,'String'));
+    numpoints = str2double(get(handles.row_number,'String'));
     point1 = data1{1};
     point2 = data2{1};
     vec = (point2 - point1)/(numpoints-1);
@@ -527,7 +527,7 @@ else
     detectors = get(handles.detectors,'String');
     data1 = textscan(p1,'%.54f');
     data2 = textscan(p2,'%.54f');
-    numpoints = str2num(get(handles.row_number,'String'));
+    numpoints = str2double(get(handles.row_number,'String'));
     point1 = data1{1};
     point2 = data2{1};
     vec = (point2 - point1)/(numpoints-1);

--- a/gui/gui_view_solution.m
+++ b/gui/gui_view_solution.m
@@ -248,7 +248,7 @@ if fn == 0
     return;
 end
 temp = [pn fn];
-k = findstr(temp,'_');
+k = strfind(temp,'_');
 set(handles.solution,'String',temp(1:max(k)-1));
 
 guidata(hObject, handles);

--- a/gui/mygenvarname.m
+++ b/gui/mygenvarname.m
@@ -13,9 +13,9 @@ function varname = mygenvarname(pathloc)
 % varname is the resulting variable name
 
 
-k1 = findstr(pathloc,'/');
-k2 = findstr(pathloc,'\');
-p = findstr(pathloc,'.');
+k1 = strfind(pathloc,'/');
+k2 = strfind(pathloc,'\');
+p = strfind(pathloc,'.');
 if length(p)>1
     pos = p(end);
 else

--- a/toolbox/get_field.m
+++ b/toolbox/get_field.m
@@ -19,7 +19,7 @@ if ispref('nirfast','solver')
     % if pardiso is chosen, make sure it's available
     if strcmp(solver,'pardiso')
         env = getenv('LD_LIBRARY_PATH');
-        if isempty(findstr(env,'pardiso'))
+        if ~contains(env,'pardiso')
             pardiso = 0;
         else
             pardiso = 1;
@@ -43,7 +43,7 @@ else
     
     % determine which solver is best
     env = getenv('LD_LIBRARY_PATH');
-    if isempty(findstr(env,'pardiso'))
+    if ~contains(env,'pardiso')
         pardiso = 0;
     else
         pardiso = 1;

--- a/toolbox/load_data.m
+++ b/toolbox/load_data.m
@@ -107,9 +107,9 @@ if ischar(fn) ~= 0
         S = char(text);
         wloc = strfind(S,'w');
         for i=1:1:numel(wloc)-1
-            data.wv(i) = str2num(strtrim(S(wloc(i)+1:wloc(i+1)-1)));
+            data.wv(i) = str2double(strtrim(S(wloc(i)+1:wloc(i+1)-1)));
         end
-        data.wv(end+1) = str2num(strtrim(S(wloc(end)+1:end)));
+        data.wv(end+1) = str2double(strtrim(S(wloc(end)+1:end)));
         
         % finish writing link
         data.link = [data.link datatemp(:,1:3:end)];

--- a/toolbox/meshing/checkerboard3dmm/checkerboard3d.m
+++ b/toolbox/meshing/checkerboard3dmm/checkerboard3d.m
@@ -108,7 +108,7 @@ if silentflag==0
     answer=inputdlg(prompt,name,numlines,defaultanswer);
     % We should add an option that user can choose an Size function:
     % ds=GetEdgeSizeAtXY(p(t(i,j),:),density);
-    ds = str2num(answer{1});
+    ds = str2double(answer{1});
     % ds=2;
 else
     if isfield(myargs,'edgesize') && ~isempty(myargs.edgesize)

--- a/toolbox/meshing/image2mesh_cgal/image2mesh_gui.m
+++ b/toolbox/meshing/image2mesh_cgal/image2mesh_gui.m
@@ -642,9 +642,9 @@ else
     
     % find singleton dimension for use in reordering fiducial coords
     dim = [0 0 0];
-    dim(1) = str2num(get(handles.nrows,'String'));
-    dim(2) = str2num(get(handles.ncols,'String'));
-    dim(3) = str2num(get(handles.nslices,'String'));
+    dim(1) = str2double(get(handles.nrows,'String'));
+    dim(2) = str2double(get(handles.ncols,'String'));
+    dim(3) = str2double(get(handles.nslices,'String'));
     sing_dim = find(dim==1);
     
     % reorder coords based on singleton dimension
@@ -702,7 +702,7 @@ else
     %content{end+1} = strcat('mask2mesh_2D(flipdim(rot90(mask.'',2),2),[',pix_dim,'],',...
     content{end+1} = strcat('mask2mesh_2D(rot90(mask,1),[',pix_dim,'],',...
         get(handles.cell_size,'String'),...
-        ',',num2str((str2num(get(handles.cell_size,'String'))^2)/2),...
+        ',',num2str((str2double(get(handles.cell_size,'String'))^2)/2),...
         ',''',[savefn_ '_nirfast_mesh'],...
         ''',''',handles.meshtype,''',[',num2str(offset),']);');
     if ~batch

--- a/toolbox/meshing/tools/GetFilenameNumbering.m
+++ b/toolbox/meshing/tools/GetFilenameNumbering.m
@@ -19,7 +19,7 @@ if ~isempty(idx) && idx
     foo = dir([fullfile(path,fnprefix) '*' ext]);
     foo = foo(1).name;
     idx = regexpi(foo,['[0-9]+' ext '\>']);
-    num_flag = str2num(foo(idx:end-4));
+    num_flag = str2double(foo(idx:end-4));
 else
     num_flag=-1;
 end

--- a/toolbox/meshing/tools/loadinr.m
+++ b/toolbox/meshing/tools/loadinr.m
@@ -141,7 +141,7 @@ if (fid > 0)
     error('[LoadInr] Invalid header XDIM (%s).',name);
   end
   pos_=find(0+header(pos:end)==10);
-  h.xdim=str2num(header(pos+5:pos_(1)-2+pos));
+  h.xdim=str2double(header(pos+5:pos_(1)-2+pos));
   if isempty(h.xdim)
     error('[LoadInr] Invalid XDIM (%s).',name);
   end
@@ -152,7 +152,7 @@ if (fid > 0)
     error('[LoadInr] Invalid header YDIM (%s).',name);
   end
   pos_=find(0+header(pos:end)==10);
-  h.ydim=str2num(header(pos+5:pos_(1)-2+pos));
+  h.ydim=str2double(header(pos+5:pos_(1)-2+pos));
   if isempty(h.ydim)
     error('[LoadInr] Invalid YDIM (%s).',name);
   end 
@@ -163,7 +163,7 @@ if (fid > 0)
     error('[LoadInr] Invalid header ZDIM (%s).',name);
   end
   pos_=find(0+header(pos:end)==10);
-  h.zdim=str2num(header(pos+5:pos_(1)-2+pos));
+  h.zdim=str2double(header(pos+5:pos_(1)-2+pos));
   if isempty(h.zdim)
     error('[LoadInr] Invalid ZDIM (%s).',name);
   end 
@@ -174,7 +174,7 @@ if (fid > 0)
     error('[LoadInr] Invalid header VDIM (%s).',name);
   end
   pos_=find(0+header(pos:end)==10);
-  h.vdim=str2num(header(pos+5:pos_(1)-2+pos));
+  h.vdim=str2double(header(pos+5:pos_(1)-2+pos));
   if isempty(h.vdim)
     error('[LoadInr] Invalid VDIM (%s).',name);
   end
@@ -259,7 +259,7 @@ if (fid > 0)
   end
   if(~isempty(pos))
     pos_=find(0+header(pos:end)==10);
-    h.vx=str2num(header(pos+3:pos_(1)-2+pos));
+    h.vx=str2double(header(pos+3:pos_(1)-2+pos));
     if isempty(h.vx)
       error('[LoadInr] Invalid VX (%s).',name);
     end 
@@ -271,25 +271,25 @@ if (fid > 0)
   end
   if(~isempty(pos))
     pos_=find(0+header(pos:end)==10);
-    h.vy=str2num(header(pos+3:pos_(1)-2+pos));
+    h.vy=str2double(header(pos+3:pos_(1)-2+pos));
     if isempty(h.vy)
       error('[LoadInr] Invalid VY (%s).',name);
     end 
   end
   % z pixelsize
-  pos=findstr(header,'VZ=');
+  pos=strfind(header,'VZ=');
   if(length(pos)>1)
     error(sprintf('[LoadInr] Invalid header VZ (%s).',name));
   end
   if(~isempty(pos))
     pos_=find(0+header(pos:end)==10);
-    h.vz=str2num(header(pos+3:pos_(1)-2+pos));
+    h.vz=str2double(header(pos+3:pos_(1)-2+pos));
     if isempty(h.vz)
       error(sprintf('[LoadInr] Invalid VZ (%s).',name));
     end 
   end
   % scale
-  pos=findstr(header,'SCALE=');
+  pos=strfind(header,'SCALE=');
   if(length(pos)>1)
     error(sprintf('[LoadInr] Invalid header SCALE (%s).',name));
   end
@@ -303,7 +303,7 @@ if (fid > 0)
   
   % find commentlines
   com=[char(10) '#'];
-  pos=findstr(header,com);
+  pos=strfind(header,com);
   % store comments in struct not yet implemented
   
   

--- a/toolbox/meshing/tools/readMEDIT.m
+++ b/toolbox/meshing/tools/readMEDIT.m
@@ -9,7 +9,7 @@ while true
         break;
     end
 end
-nn = str2num(fgetl(fid));
+nn = str2double(fgetl(fid));
 
 data = textscan(fid,'%f %f %f%*[^\n]',nn);
 if length(data{1}) ~= nn
@@ -33,7 +33,7 @@ while true
 end
 
 if tri==1
-    nt = str2num(fgetl(fid));
+    nt = str2double(fgetl(fid));
     tris_ = textscan(fid,'%d %d %d %d%*[^\n]',nt);
     if length(tris_{1}) ~= nt
         warning('Expecting %d faces, but got %d instead!\n', nt, length(tris_{1}));
@@ -49,7 +49,7 @@ if tri==1
 end
 
 if tet==1
-    ne = str2num(fgetl(fid));
+    ne = str2double(fgetl(fid));
     data = textscan(fid,'%d %d %d %d %d%*[^\n]',ne);
     if length(data{1}) ~= ne
         warning('Expecting %d elements, but got %d instead!\n', ne, length(data));

--- a/toolbox/meshing/tools/readOFF.m
+++ b/toolbox/meshing/tools/readOFF.m
@@ -10,7 +10,7 @@ if isempty(strfind(blah,'OFF'))
 end
 
 junk = fgetl(fid);
-blah = str2num(junk);
+blah = sscanf(junk, '%f')';
 nnodes = blah(1);
 nfaces = blah(2);
 

--- a/toolbox/meshing/tools/readinr.m
+++ b/toolbox/meshing/tools/readinr.m
@@ -24,28 +24,28 @@ end
 
 nx=regexp(s,'XDIM\s*=\s*([0-9]+)','tokens');
 if(~isempty(nx)) 
-   nx=str2num(nx{1}{1});
+   nx=str2double(nx{1}{1});
 else
    error('no XDIM found');
 end
 
 ny=regexp(s,'YDIM\s*=\s*([0-9]+)','tokens');
 if(~isempty(ny)) 
-   ny=str2num(ny{1}{1});
+   ny=str2double(ny{1}{1});
 else
    error('no YDIM found');
 end
 
 nz=regexp(s,'ZDIM\s*=\s*([0-9]+)','tokens');
 if(~isempty(nz)) 
-   nz=str2num(nz{1}{1});
+   nz=str2double(nz{1}{1});
 else
    error('no ZDIM found');
 end
 
 nv=regexp(s,'VDIM\s*=\s*([0-9]+)','tokens');
 if(~isempty(nv))
-   nv=str2num(nv{1}{1});
+   nv=str2double(nv{1}{1});
 else
    nv=1;
 end
@@ -59,7 +59,7 @@ end
 
 pixel=regexp(s,'PIXSIZE=([0-9]+)','tokens');
 if(~isempty(pixel))
-   pixel=str2num(pixel{1}{1});
+   pixel=str2double(pixel{1}{1});
 else
    error('no PIXSIZE found');
 end


### PR DESCRIPTION
## Summary
- modernize string search to use `contains` or `strfind`
- prefer `str2double` over `str2num`
- refresh logic in mesh and GUI utilities

## Testing
- `grep -R "findstr(" -n | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_683f612e5120833386be5a793aa6f611